### PR TITLE
add forgotten description of the digits constructor

### DIFF
--- a/spec/fpcore-1.1.html
+++ b/spec/fpcore-1.1.html
@@ -396,6 +396,19 @@
         from the parent context. See <a href="#rounding">Rounding</a>.
       </p>
     </dd>
+
+    <dt><code>digits</code></dt>
+    <dd>
+      <p>
+        The <code>digits</code> constructor allows exact numbers to be specified
+        in any floating-point radix as a triple of significand (or mantissa),
+        exponent, and base. <code>(digits <var>m</var> <var>e</var> <var>b</var>)</code>
+        represents exactly the value <var>m</var> ✕ <var>b<sup>e</sup></var>.
+        <var>m</var>, <var>e</var>, and <var>b</var> are integers,
+        with <var>b</var> ≥ 2. The sign of the value is determined by the sign
+        of <var>m</var>.
+      </p>
+    </dd>
   </dl>
   </section>
 


### PR DESCRIPTION
Should have been included in the original PR. Oops.