### PR TITLE
Explain that decnums cannot be symbols

### DIFF
--- a/spec/fpcore-1.1.html
+++ b/spec/fpcore-1.1.html
@@ -130,12 +130,6 @@
   </p>
 
   <dl class="code-terms">
-    <dt id="g:symbol">symbol</dt>
-    <dd>Any sequence of letters, digits, or characters from the
-      set <code>~!@$%^&*_-+=<>.?/:</code> not starting with a digit,
-      implemented for ASCII by the regular expression:
-      <pre class="expr"><code>[a-zA-Z~!@$%^&*_\-+=<>.?/:][a-zA-Z0-9~!@$%^&*_\-+=<>.?/:]*</code></pre></dd>
-
     <dt id="g:decnum">decnum</dt>
     <dd>An optional plus (<code>+</code>) or minus (<code>-</code>)
       sign followed by either a sequence of decimal digits which
@@ -163,6 +157,13 @@
       a slash (<code>/</code>), followed by a nonzero sequence of decimal digits that
       form the denominator. This definition is implemented for ASCII by the regular expression:
       <pre class="expr"><code>[+-]?[0-9]+/[0-9]*[1-9][0-9]*</code></pre></dd>
+
+    <dt id="g:symbol">symbol</dt>
+    <dd>Any sequence of letters, digits, or characters from the
+      set <code>~!@$%^&*_-+=<>.?/:</code> not starting with a digit
+      and not matching any other basic token.
+      In ASCII, all symbols match by this regular expression:
+      <pre class="expr"><code>[a-zA-Z~!@$%^&*_\-+=<>.?/:][a-zA-Z0-9~!@$%^&*_\-+=<>.?/:]*</code></pre></dd>
 
     <dt id="g:string">string</dt>
     <dd>Any sequence of printable characters, spaces, tabs, or


### PR DESCRIPTION
FPCore 1.0 had a bug in that certain `<decnum>`s, like `-1.0`, were also `<symbol>`s. This could in principle lead to misparsings by apparently-conforming implementations. This pull request modifies the standard to clarify that anything that matches a `<decnum>`, or other base token, is not a `<symbol>`.

The intended implementation is to tokenize by matching the other regular expressions first, and then matching the symbol regex.