### PR TITLE
Allow arbitrary S-expression values for property

### DIFF
--- a/fpbench.css
+++ b/fpbench.css
@@ -45,7 +45,12 @@ a[href*=\#g\:]:before { content: "‹" }
 a[href*=\#g\:]:after { content: "›" }
 a[href*=\#g\:] { color: #204a87; text-decoration: none; font-family: mono; font-size: 88%; }
 
-aside { border: 1px solid black; width: 200px; float: right; clear: right; padding: 24px; margin: 0 25px; }
+figure { margin-right: 0; }
+aside {
+    border: 1px solid black; width: 200px;
+    float: right; clear: right; padding: 24px; margin: 1em 25px;
+    font-family: Helvetica, Arial, sans; font-size: 18px;
+}
 
 @media (min-width: 1200px) {
     body.gutter { padding-right: 300px; }

--- a/spec/fpcore-1.1.html
+++ b/spec/fpcore-1.1.html
@@ -81,13 +81,13 @@
     <dl class="grammar">
       <dt id="g:fpcore">FPCore</dt>
       <dd>( FPCore (<a href="#g:argument" title="Free variables in benchmark">argument</a>*)
-        <a href="#g:property" title="Metadata properties of the benchmark">property</a>*
+        <a href="metadata-1.1.html#g:property" title="Metadata properties of the benchmark">property</a>*
         <a href="#g:expr" title="Benchmark expression">expr</a> )
       </dd>
 
       <dt id="g:argument">argument</dt>
       <dd><a href="#g:symbol" title="Name of free variable">symbol</a></dd>
-      <dd>( ! <a href="#g:property" title="Rounding context for free variable">property</a>* <a href="#g:symbol" title="Name of free variable">symbol</a> )</dd>
+      <dd>( ! <a href="metadata-1.1.html#g:property" title="Rounding context for free variable">property</a>* <a href="#g:symbol" title="Name of free variable">symbol</a> )</dd>
 
       <dt id="g:expr">expr</dt>
       <dd><a href="#g:number" title="A number">number</a></dd>
@@ -98,20 +98,15 @@
       <dd>( let ( [ <a href="#g:symbol" title="Variable being bound">symbol</a> <a href="#g:expr" title="Value of variable">expr</a> ]* ) <a href="#g:expr" title="Body expression to evaluate with bindings">expr</a> )</dd>
       <dd>( while <a href="#g:expr" title="Loop condition">expr</a> ( [ <a href="#g:symbol" title="Variable mutated in loop">symbol</a> <a href="#g:expr" title="Initial variable value">expr</a> <a href="#g:expr" title="Update expression for variable">expr</a> ]* ) <a href="#g:expr" title="Body expression to evaluate after loop">expr</a> )</dd>
       <dd>( cast <a href="#g:expr" title="Expression to round with current rounding context">expr</a> )</dd>
-      <dd>( ! <a href="#g:property" title="Rounding context for expression">property</a>* <a href="#g:expr" title="Expression annotated by rounding context">expr</a> )</dd>
+      <dd>( ! <a href="metadata-1.1.html#g:property" title="Rounding context for expression">property</a>* <a href="#g:expr" title="Expression annotated by rounding context">expr</a> )</dd>
 
       <dt id="g:number">number</dt>
       <dd><a href="#g:decnum" title="A decimal number literal">decnum</a></dd>
       <dd><a href="#g:hexnum" title="A hexadecimal number literal">hexnum</a></dd>
       <dd><a href="#g:rational" title="A rational number">rational</a></dd>
       <dd>( digits <a href="#g:decnum" title="Significand">decnum</a> <a href="#g:decnum" title="Exponent">decnum</a> <a href="#g:decnum" title="Base">decnum</a> )</dd>
-
-      <dt id="g:property">property</dt>
-      <dd>:<a href="#g:symbol" title="Property name">symbol</a> <a href="#g:expr" title="Property value given as expression">expr</a></dd>
-      <dd>:<a href="#g:symbol" title="Property name">symbol</a> <a href="#g:string" title="Property value given as string">string</a></dd>
-      <dd>:<a href="#g:symbol" title="Property name">symbol</a> ( <a href="#g:symbol" title="Property value given as list of symbols">symbol</a>* )</dd>
     </dl>
-    <caption>High-level grammar of FPCore. The tokens <a href="#g:constant">constant</a> and <a href="#g:operation">operation</a>, as well as base tokens like <a href="#g:decnum">decnum</a>, are defined below. </caption>
+    <caption>High-level grammar of FPCore. The tokens <a href="#g:constant">constant</a> and <a href="#g:operation">operation</a>, as well as base tokens like <a href="#g:decnum">decnum</a>, are defined below, while <a href="metadata-1.1.html#g:property">property</a> is defined in <a href="metadata-1.1.html">the Metadata 1.1</a> standard. </caption>
   </figure>
 
   <aside>

--- a/spec/fpcore-1.1.html
+++ b/spec/fpcore-1.1.html
@@ -81,13 +81,13 @@
     <dl class="grammar">
       <dt id="g:fpcore">FPCore</dt>
       <dd>( FPCore (<a href="#g:argument" title="Free variables in benchmark">argument</a>*)
-        <a href="metadata-1.1.html#g:property" title="Metadata properties of the benchmark">property</a>*
+        <a href="#g:property" title="Metadata properties of the benchmark">property</a>*
         <a href="#g:expr" title="Benchmark expression">expr</a> )
       </dd>
 
       <dt id="g:argument">argument</dt>
       <dd><a href="#g:symbol" title="Name of free variable">symbol</a></dd>
-      <dd>( ! <a href="metadata-1.1.html#g:property" title="Rounding context for free variable">property</a>* <a href="#g:symbol" title="Name of free variable">symbol</a> )</dd>
+      <dd>( ! <a href="#g:property" title="Rounding context for free variable">property</a>* <a href="#g:symbol" title="Name of free variable">symbol</a> )</dd>
 
       <dt id="g:expr">expr</dt>
       <dd><a href="#g:number" title="A number">number</a></dd>
@@ -98,15 +98,33 @@
       <dd>( let ( [ <a href="#g:symbol" title="Variable being bound">symbol</a> <a href="#g:expr" title="Value of variable">expr</a> ]* ) <a href="#g:expr" title="Body expression to evaluate with bindings">expr</a> )</dd>
       <dd>( while <a href="#g:expr" title="Loop condition">expr</a> ( [ <a href="#g:symbol" title="Variable mutated in loop">symbol</a> <a href="#g:expr" title="Initial variable value">expr</a> <a href="#g:expr" title="Update expression for variable">expr</a> ]* ) <a href="#g:expr" title="Body expression to evaluate after loop">expr</a> )</dd>
       <dd>( cast <a href="#g:expr" title="Expression to round with current rounding context">expr</a> )</dd>
-      <dd>( ! <a href="metadata-1.1.html#g:property" title="Rounding context for expression">property</a>* <a href="#g:expr" title="Expression annotated by rounding context">expr</a> )</dd>
+      <dd>( ! <a href="#g:property" title="Rounding context for expression">property</a>* <a href="#g:expr" title="Expression annotated by rounding context">expr</a> )</dd>
 
       <dt id="g:number">number</dt>
       <dd><a href="#g:decnum" title="A decimal number literal">decnum</a></dd>
       <dd><a href="#g:hexnum" title="A hexadecimal number literal">hexnum</a></dd>
       <dd><a href="#g:rational" title="A rational number">rational</a></dd>
       <dd>( digits <a href="#g:decnum" title="Significand">decnum</a> <a href="#g:decnum" title="Exponent">decnum</a> <a href="#g:decnum" title="Base">decnum</a> )</dd>
+
+      <dt id="g:property">property</dt>
+      <dd>:<a href="fpcore-1.1.html#g:symbol" title="Property name">symbol</a> <a href="#g:data" title="Property value">data</a></dd>
+
+      <aside>
+        Note that metadata can contain
+        arbitrary <a href="fpcore-1.1.html#g:data">data</a>, including
+        expressions. Implementations may want to special-case
+        properties whose values are expressions, to simplify support
+        for <a href="metadata-1.1.html#p:pre">:pre</a>
+        and <a href="metadata-1.1.html#p:spec">:spec</a>.
+      </aside>
+
+      <dt id="g:data">data</dt>
+      <dd><a href="fpcore-1.1.html#g:symbol" title="Symbols are a datum">symbol</a></dd>
+      <dd><a href="fpcore-1.1.html#g:number" title="Numbers are a datum">number</a></dd>
+      <dd><a href="fpcore-1.1.html#g:string" title="Strings are a datum">string</a></dd>
+      <dd>( <a href="#g:data" title="Several data are a datum">data</a>* )</dd>
     </dl>
-    <caption>High-level grammar of FPCore. The tokens <a href="#g:constant">constant</a> and <a href="#g:operation">operation</a>, as well as base tokens like <a href="#g:decnum">decnum</a>, are defined below, while <a href="metadata-1.1.html#g:property">property</a> is defined in <a href="metadata-1.1.html">the Metadata 1.1</a> standard. </caption>
+    <caption>High-level grammar of FPCore. The tokens <a href="#g:constant">constant</a> and <a href="#g:operation">operation</a>, as well as base tokens like <a href="#g:decnum">decnum</a>, are defined below. </caption>
   </figure>
 
   <aside>

--- a/spec/metadata-1.1.html
+++ b/spec/metadata-1.1.html
@@ -53,21 +53,6 @@
   property in its output to indicate how long it took to rewrite the benchmark.
 </aside>
 
-<figure>
-  <dl class="grammar">
-      <dt id="g:property">property</dt>
-      <dd>:<a href="fpcore-1.1.html#g:symbol" title="Property name">symbol</a> <a href="#g:data" title="Property value">data</a></dd>
-
-      <dt id="g:data">data</dt>
-      <dd><a href="fpcore-1.1.html#g:symbol" title="Symbols are a datum">symbol</a></dd>
-      <dd><a href="fpcore-1.1.html#g:number" title="Numbers are a datum">number</a></dd>
-      <dd><a href="fpcore-1.1.html#g:string" title="Strings are a datum">string</a></dd>
-      <dd>( <a href="#g:data" title="Several data are a datum">data</a>* )</dd>
-  </dl>
-
-  <caption>Grammar for metadata properties and values. Definitions of base tokens like <a href="fpcore-1.1.html#g:symbol">symbol</a> are found in <a href="fpcore-1.1.html">the FPCore 1.1</a> standard.</caption>
-</figure>
-
 <p>
   FPBench 1.1 defines the meaning of the following properties:
 </p>

--- a/spec/metadata-1.1.html
+++ b/spec/metadata-1.1.html
@@ -53,6 +53,21 @@
   property in its output to indicate how long it took to rewrite the benchmark.
 </aside>
 
+<figure>
+  <dl class="grammar">
+      <dt id="g:property">property</dt>
+      <dd>:<a href="fpcore-1.1.html#g:symbol" title="Property name">symbol</a> <a href="#g:data" title="Property value">data</a></dd>
+
+      <dt id="g:data">data</dt>
+      <dd><a href="fpcore-1.1.html#g:symbol" title="Symbols are a datum">symbol</a></dd>
+      <dd><a href="fpcore-1.1.html#g:number" title="Numbers are a datum">number</a></dd>
+      <dd><a href="fpcore-1.1.html#g:string" title="Strings are a datum">string</a></dd>
+      <dd>( <a href="#g:data" title="Several data are a datum">data</a>* )</dd>
+  </dl>
+
+  <caption>Grammar for metadata properties and values. Definitions of base tokens like <a href="fpcore-1.1.html#g:symbol">symbol</a> are found in <a href="fpcore-1.1.html">the FPCore 1.1</a> standard.</caption>
+</figure>
+
 <p>
   FPBench 1.1 defines the meaning of the following properties:
 </p>


### PR DESCRIPTION
One of my colleagues emailed me to point out that our fairly restrictive grammar for property values is violated by our own FPBench benchmarks, such as the `:example` properties in some benchmarks, since they contain lists of pairs of symbols and numbers, while FPCore 1.0 only allows strings, lists of symbols, and expressions. This PR changes property values to be arbitrary S-expression data containing symbols, numbers, and strings. That should better match what people actually implement today.