### PR TITLE
Link to Alexey's new FPBenchJS site

### DIFF
--- a/benchmarks.js
+++ b/benchmarks.js
@@ -160,7 +160,7 @@ Tool("Herbie", function(core) {
 
 Tool("FPTaylor", function(core) {
     if (!core.core_fptaylor) return false;
-    return "http://fptaylor.cs.utah.edu/run?input=" + encodeURIComponent(core.core_fptaylor);
+    return "https://monadius.github.io/FPTaylorJS/#/?input=" + encodeURIComponent(core.core_fptaylor) + "&config=rel-error%3Dtrue#/";
 })
 
 function render_result(core) {


### PR DESCRIPTION
@monadius has built a new version of FPTaylor that can be run as pure Javascript: https://monadius.github.io/FPTaylorJS/

This updates the FPBench benchmarks page to link to it.