### PR TITLE
Add advisory board page

### DIFF
--- a/advisory-board.html
+++ b/advisory-board.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>FPBench - Advisory Board</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" type="text/css" href="fpbench.css">
+</head>
+<body>
+  <header>
+    <a href='.'>
+      <img src='img/logo.png' height='150' alt='FPBench Logo' />
+      <h1>FPBench</h1>
+    </a>
+    <p>Numerics community meetings and resources</p>
+    <ul>
+      <li><a href="index.html">Events</a></li>
+      <li><a href="education.html">Education</a></li>
+      <li><a href="community.html">Tools</a></li>
+      <li><a href="https://groups.google.com/a/fpbench.org/g/fpbench">Mailing List</a></li>
+    </ul>
+  </header>
+
+  <h2>Advisory Board</h2>
+
+  <p>The FPBench advisory board helps organize and maintain the organization.</p>
+
+  <ul>
+    <li><a href='https://pavpanchekha.com/'>Pavel Panchekha</a>, University of Utah</li>
+    <li><a href='https://avolkova.org/'>Anastasia Volkova</a>, INRIA</li>
+    <li>Bill Zorn, Intel</li>
+    <li><a href='https://ianbriggs.dev/'>Ian Briggs</a>, University of Utah</li>
+    <li><a href='https://www.linkedin.com/in/theo-drane-7753934/'>Theo Drane</a>, Intel</li>
+    <li><a href='https://www.linkedin.com/in/theodoreomtzigt/'>Theodore Omtzigt</a>, Lemurian Labs</li>
+    <li><a href='https://ztatlock.net/'>Zachary Tatlock</a>, University of Washington</li>
+  </ul>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add advisory board page listing advisory board members and affiliations

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689e058cbfe4832198a80843433bf84e