### PR TITLE
Rebrand community-facing pages from FPBench to FPTalks

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>FPBench - About</title>
+  <title>FPTalks - About</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" type="text/css" href="fpbench.css">
 </head>
@@ -11,8 +11,8 @@
 <body>
   <header>
     <a href='.'>
-      <img src='img/logo.png' height='150' alt='FPBench Logo' />
-      <h1>FPBench</h1>
+      <img src='img/logo.png' height='150' alt='FPTalks Logo' />
+      <h1>FPTalks</h1>
     </a>
     <p>Numerics community meetings and resources</p>
     <ul>
@@ -24,13 +24,13 @@
     </ul>
   </header>
 
-  <h2>About FPBench</h2>
+  <h2>About FPTalks</h2>
 
   <h3>Numerics community meetings and resources</h3>
 
   <p>
-    FPBench is a community-led initiative advancing floating-point research.
-    At the center of our work is FPTalks, a monthly virtual seminar series that brings
+    FPTalks is a community-led initiative advancing floating-point research.
+    At the center of our work is a monthly virtual seminar series that brings
     together researchers, practitioners, and tool developers from across academia
     and industry to share the latest work in floating-point analysis, optimization,
     verification, and numerics education.
@@ -39,7 +39,7 @@
     We aim to build a collaborative community by organizing
     events, curating technical resources, and developing shared
     infrastructure for reproducible floating-point research.
-    FPBench also supports
+    FPTalks also supports
     long-term growth in the field by developing educational materials and
     facilitating mentorship connections across academia, industry, and national
     labs.
@@ -53,15 +53,15 @@
   <h2>Community Meetings</h2>
 
   <ul>
-    <li><a href='https://fpbench.org'>Monthly Talk Series</a></li>
-    <li><a href='https://fpbench.org/talks'>Annual Workshop</a></li>
+    <li><a href='https://fptalks.org'>FPTalks Seminar</a></li>
+    <li><a href='https://fptalks.org/talks'>Annual Workshop</a></li>
   </ul>
 
   <h2>Staying in Touch</h2>
 
   <ul>
-    <li><a href='https://fpbench.org/subscribe'>Join our mailing list</a></li>
-    <li><a href='https://fpbench.org/nominate'>Sign up to present</a></li>
+    <li><a href='https://fptalks.org/subscribe'>Join our mailing list</a></li>
+    <li><a href='https://fptalks.org/nominate'>Sign up to present</a></li>
   </ul>
 
 

--- a/community.html
+++ b/community.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='.' style='color: black; text-decoration: none;'>
-      <img src='img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks Community Tools</h1>
     </a>
     <p>Numerics research tools and systems</p>

--- a/education.html
+++ b/education.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='.' style='color: black; text-decoration: none;'>
-      <img src='img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks Education Resources</h1>
     </a>
     <p>Numerics papers, slides, and videos</p>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>FPBench</title>
+  <title>FPTalks</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" type="text/css" href="fpbench.css">
 
@@ -51,8 +51,8 @@
 <body>
   <header>
     <a href='index.html'>
-      <img src='img/logo.png' height='150' alt='FPBench Logo' />
-      <h1>FPBench</h1>
+      <img src='img/logo.png' height='150' alt='FPTalks Logo' />
+      <h1>FPTalks</h1>
     </a>
     <p>Numerics community meetings and resources</p>
     <ul>
@@ -69,7 +69,7 @@
   </div>
 
   <p id='info'>
-    FPBench meets for an hour, on Zoom, on the first Thursday of every month at 9am Pacific.<abbr
+    FPTalks meets for an hour, on Zoom, on the first Thursday of every month at 9am Pacific.<abbr
       title="Except that we skip months for the annual workshop and for the winter holidays."><sup>&dagger;</sup></abbr>
     You can <a href="https://forms.gle/H5aodraRcgcJFq6W8">submit a proposal</a> to present.
   </p>

--- a/talks/fptalks20.html
+++ b/talks/fptalks20.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2020</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -48,7 +48,7 @@
         <ul class="links">
           <li><a href="https://youtu.be/eyD5oF507g8">Video</a></li>
           <li><a href="https://drive.google.com/uc?export=download&id=1Tf1Zt6cl7AoLbAVhELD8QRlXEgwwgGyD">Slides</a></li>
-          <li><a href="/">FPBench</a></li>
+          <li><a href="/">FPTalks</a></li>
         </ul>
         <h3>AdaptivFloat: A data type for resilient deep learning inference</h3>
         <p>Thierry Tambe, Harvard University</p>

--- a/talks/fptalks21.html
+++ b/talks/fptalks21.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2021</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -39,7 +39,7 @@
         <p>Pavel Panchekha, University of Utah</p>
         <ul class="links">
           <li><a href="https://drive.google.com/file/d/1k8bSZFPSCJpOkWBRtAHKYJcFS0sy-pYG/view?usp=sharing">Slides</a></li>
-          <li><a href="/">FPBench</a></li>
+          <li><a href="/">FPTalks</a></li>
         </ul>
         <h3>A Two-Phase Approach for Conditional Floating-Point Verification</h3>
         <p>Debasmita Lohar, Max Planck Institute</p>

--- a/talks/fptalks22.html
+++ b/talks/fptalks22.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2022</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -45,7 +45,7 @@
            Bill Zorn, Intel</p>
         <ul class="links">
           <li><a href="https://www.youtube.com/watch?v=NzVK3diMZHw">Recording</a></li>
-          <li><a href="/">FPBench</a></li>
+          <li><a href="/">FPTalks</a></li>
         </ul>
 
         <h3>The hardware costs of Posits and IEEE floating-point</h3>

--- a/talks/fptalks23.html
+++ b/talks/fptalks23.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2023</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -143,7 +143,7 @@
     <div>
       <p>
         For more information,
-        please see the <a href="https://fpbench.org/">FPBench project</a>
+        please see the <a href="https://fptalks.org/">FPTalks community</a>
         and check out past recordings from <a href="fptalks22.html">FPTalks 2022</a>,
         <a href="fptalks21.html">FPTalks 2021</a>
         and <a href="fptalks20.html">FPTalks 2020</a>.

--- a/talks/fptalks24.html
+++ b/talks/fptalks24.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2024</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -183,7 +183,7 @@
     <div>
       <p>
         For more information,
-        please see the <a href="https://fpbench.org/">FPBench project</a>
+        please see the <a href="https://fptalks.org/">FPTalks community</a>
         and check out past recordings from:
       </p>
       <ul>

--- a/talks/fptalks25.html
+++ b/talks/fptalks25.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <a href='../index.html'>
-      <img src='../img/logo.png' height='150' alt='FPBench Logo' />
+      <img src='../img/logo.png' height='150' alt='FPTalks Logo' />
       <h1>FPTalks 2025</h1>
     </a>
     <p>The leading edge of floating-point research</p>
@@ -206,7 +206,7 @@
     <div>
       <p>
         For more information,
-        please see the <a href="https://fpbench.org/">FPBench project</a>
+        please see the <a href="https://fptalks.org/">FPTalks community</a>
         and check out past recordings from:
       </p>
       <ul>


### PR DESCRIPTION
## Summary

- Title tags, header h1, logo alt text updated on all community-facing pages
- About page body text rebranded, URLs changed from fpbench.org to fptalks.org
- Monthly talk series renamed to "FPTalks Seminar"
- Workshop page footer links and breadcrumbs updated
- 10 files, 29 lines changed

## What's NOT in this PR

- CNAME change (DNS flip is a separate step)
- Spec pages, benchmark pages, papers pages (these correctly refer to the FPBench project)
- Talk abstracts (speakers' own words mentioning "FPBench")
- Google Group URLs (can't change without migrating the group)
- Logo image (staying as-is for now)
- CSS filename (cosmetic, not user-facing)

## How to deploy

1. Merge this PR
2. Zach flips DNS: fptalks.org points to GitHub Pages, fpbench.org redirects to fptalks.org
3. Update CNAME file in a follow-up commit

## Test plan

- [ ] Verify fptalks.org URLs work (currently redirect to fpbench.org, so links are valid in both directions)
- [ ] Check all page headers render correctly
- [ ] Confirm spec pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)